### PR TITLE
Add DevSecOps portfolio hardening docs and automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,18 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    - cron: '57 4 * * 1'
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@v3

--- a/docs/hiring_manager_summary.md
+++ b/docs/hiring_manager_summary.md
@@ -1,0 +1,28 @@
+# Hiring Manager Summary
+
+## What this project demonstrates
+
+DevSecOps-Reference-Pipeline demonstrates how lightweight security and quality checks can be embedded into a GitHub Actions workflow.
+
+The project is designed as a reference pipeline rather than a production platform.
+
+## Relevant roles
+
+- DevSecOps Engineer
+- Security Automation Analyst
+- Cloud / Platform Security Analyst
+- Software Security / AppSec entry-level roles
+- Cybersecurity GRC roles involving CI/CD control evidence
+
+## What this demonstrates
+
+- Secure CI/CD thinking.
+- Linting, test and SAST gates.
+- Dependency audit integration.
+- Secret scanning with Gitleaks.
+- Minimal workflow permissions.
+- A practical portfolio example of security controls in delivery workflows.
+
+## Current limitations
+
+The project does not yet include SBOM generation, signed releases, container scanning, IaC scanning or policy-as-code enforcement.


### PR DESCRIPTION
## Summary

Adds additional portfolio hardening around the DevSecOps reference pipeline.

## Added

- Dependabot configuration
- CodeQL workflow
- Hiring-manager summary

## Notes

The existing secure CI workflow already includes linting, tests, Bandit, pip-audit and Gitleaks; this PR adds supporting automation and employer-facing documentation.